### PR TITLE
Fix built run

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,2 +1,3 @@
 build:
     pyinstaller --noconfirm ./md2shunn/cli.py
+    mkdir dist/cli/_internal/docx/parts


### PR DESCRIPTION
Fixes `FileNotFoundError: [Errno 2] No such file or directory: '/home/drive/www/junk/md2shunn/dist/cli/_internal/docx/parts/../templates/default-header.xml'` error